### PR TITLE
Bug fix find bats for experts

### DIFF
--- a/src/main/kotlin/de/xai/handwriting_labeling_app_backend/service/BatchService.kt
+++ b/src/main/kotlin/de/xai/handwriting_labeling_app_backend/service/BatchService.kt
@@ -150,7 +150,7 @@ class BatchService(
                 .filter { (_, answers) ->
                     !answers.any { it.user?.id == userId }
                     && answers.size < targetAnswerCount
-                    && !(forExpert && targetExpertAnswerCount > answers.filter { it.isFromExpert() }.size)
+                            && !(forExpert && answers.filter { it.isFromExpert() }.size > targetExpertAnswerCount)
                 }
             pendingAnswersCount += availableTasks.size
 


### PR DESCRIPTION
- swapped bigger than operator, to exclude samples that have too many expert answers, rather than excluding samples that have too few expert answers.