### PR TITLE
Follow up to hot fix

### DIFF
--- a/src/main/kotlin/de/xai/handwriting_labeling_app_backend/service/BatchService.kt
+++ b/src/main/kotlin/de/xai/handwriting_labeling_app_backend/service/BatchService.kt
@@ -150,7 +150,7 @@ class BatchService(
                 .filter { (_, answers) ->
                     !answers.any { it.user?.id == userId }
                     && answers.size < targetAnswerCount
-                            && !(forExpert && answers.filter { it.isFromExpert() }.size > targetExpertAnswerCount)
+                            && !(forExpert && answers.filter { it.isFromExpert() }.size >= targetExpertAnswerCount)
                 }
             pendingAnswersCount += availableTasks.size
 


### PR DESCRIPTION
- corrected expert answer filter. Now samples are excluded when they have targetExpertAnswerCount answers, no if they have more than that as previously